### PR TITLE
Add combat log export support

### DIFF
--- a/src/StatisticsAnalysisTool/Localization/localization.json
+++ b/src/StatisticsAnalysisTool/Localization/localization.json
@@ -21067,6 +21067,55 @@
       ]
     },
     {
+      "tuid": "EXPORT_COMBAT_LOG_TO_CSV",
+      "tuv": [
+        {
+          "lang": "de-DE",
+          "seg": "Kampfprotokoll als CSV exportieren"
+        },
+        {
+          "lang": "en-US",
+          "seg": "Export combat log to CSV"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Exportar registro de combate a CSV"
+        },
+        {
+          "lang": "fr-FR",
+          "seg": "Exporter le journal de combat en CSV"
+        },
+        {
+          "lang": "ja-JP",
+          "seg": "戦闘ログをCSVにエクスポート"
+        },
+        {
+          "lang": "ko-KR",
+          "seg": "전투 로그를 CSV로 내보내기"
+        },
+        {
+          "lang": "pl-PL",
+          "seg": "Eksportuj dziennik walk do CSV"
+        },
+        {
+          "lang": "pt-BR",
+          "seg": "Exportar registro de combate para CSV"
+        },
+        {
+          "lang": "ru-RU",
+          "seg": "Экспорт боевого лога в CSV"
+        },
+        {
+          "lang": "zh-CN",
+          "seg": "将战斗日志导出为CSV"
+        },
+        {
+          "lang": "zh-TW",
+          "seg": "將戰鬥日誌匯出為CSV"
+        }
+      ]
+    },
+    {
       "tuid": "TRACK_PARTY_LOOT_ONLY",
       "tuv": [
         {

--- a/src/StatisticsAnalysisTool/Models/TranslationModel/MainWindowTranslation.cs
+++ b/src/StatisticsAnalysisTool/Models/TranslationModel/MainWindowTranslation.cs
@@ -63,6 +63,7 @@ public class MainWindowTranslation
     public static string ResetTodaysDungeons => LocalizationController.Translation("RESET_TODAYS_DUNGEONS");
     public static string SeasonPoints => LocalizationController.Translation("SEASON_POINTS");
     public static string ExportLootToFile => LocalizationController.Translation("EXPORT_LOOT_TO_FILE");
+    public static string ExportCombatLogToCsv => LocalizationController.Translation("EXPORT_COMBAT_LOG_TO_CSV");
     public static string TrackPartyLootOnly => LocalizationController.Translation("TRACK_PARTY_LOOT_ONLY");
     public static string TrackingSilver => LocalizationController.Translation("TRACKING_SILVER");
     public static string TrackingFame => LocalizationController.Translation("TRACKING_FAME");

--- a/src/StatisticsAnalysisTool/ViewModels/MainWindowViewModel.cs
+++ b/src/StatisticsAnalysisTool/ViewModels/MainWindowViewModel.cs
@@ -396,6 +396,30 @@ public class MainWindowViewModel : BaseViewModel
         }
     }
 
+    public void ExportCombatLogToFile()
+    {
+        var dialog = new SaveFileDialog
+        {
+            FileName = $"combat-log-{DateTime.UtcNow:yyyy-MM-dd-hh-mm-ss}utc",
+            DefaultExt = ".csv",
+            Filter = "CSV documents (.csv)|*.csv"
+        };
+
+        var result = dialog.ShowDialog();
+        if (result == true)
+        {
+            try
+            {
+                var trackingController = ServiceLocator.Resolve<TrackingController>();
+                File.WriteAllText(dialog.FileName, trackingController?.CombatController?.GetCombatEventsAsCsv());
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "{message}", MethodBase.GetCurrentMethod()?.DeclaringType);
+            }
+        }
+    }
+
     #endregion
 
     #region Item View Filters


### PR DESCRIPTION
## Summary
- add a combat log export helper that mirrors the loot export workflow
- surface a new translation entry for the combat log export action

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68c8a899c2248321bc48d35c5ac752f3