### PR TITLE
Add combat log CSV export option

### DIFF
--- a/src/StatisticsAnalysisTool/Localization/localization.json
+++ b/src/StatisticsAnalysisTool/Localization/localization.json
@@ -21067,6 +21067,55 @@
       ]
     },
     {
+      "tuid": "EXPORT_COMBAT_LOG_TO_FILE",
+      "tuv": [
+        {
+          "lang": "de-DE",
+          "seg": "Kampflog als Datei exportieren"
+        },
+        {
+          "lang": "en-US",
+          "seg": "Export combat log to file"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Exportar registro de combate a archivo"
+        },
+        {
+          "lang": "fr-FR",
+          "seg": "Exporter le journal de combat vers un fichier"
+        },
+        {
+          "lang": "ja-JP",
+          "seg": "戦闘ログをファイルにエクスポート"
+        },
+        {
+          "lang": "ko-KR",
+          "seg": "전투 로그를 파일로 내보내기"
+        },
+        {
+          "lang": "pl-PL",
+          "seg": "Eksportuj dziennik walki do pliku"
+        },
+        {
+          "lang": "pt-BR",
+          "seg": "Exportar registro de combate para arquivo"
+        },
+        {
+          "lang": "ru-RU",
+          "seg": "Экспорт журнала боя в файл"
+        },
+        {
+          "lang": "zh-CN",
+          "seg": "将战斗日志导出到文件"
+        },
+        {
+          "lang": "zh-TW",
+          "seg": "將戰鬥日誌匯出到檔案"
+        }
+      ]
+    },
+    {
       "tuid": "TRACK_PARTY_LOOT_ONLY",
       "tuv": [
         {

--- a/src/StatisticsAnalysisTool/Models/TranslationModel/MainWindowTranslation.cs
+++ b/src/StatisticsAnalysisTool/Models/TranslationModel/MainWindowTranslation.cs
@@ -63,6 +63,7 @@ public class MainWindowTranslation
     public static string ResetTodaysDungeons => LocalizationController.Translation("RESET_TODAYS_DUNGEONS");
     public static string SeasonPoints => LocalizationController.Translation("SEASON_POINTS");
     public static string ExportLootToFile => LocalizationController.Translation("EXPORT_LOOT_TO_FILE");
+    public static string ExportCombatLogToFile => LocalizationController.Translation("EXPORT_COMBAT_LOG_TO_FILE");
     public static string TrackPartyLootOnly => LocalizationController.Translation("TRACK_PARTY_LOOT_ONLY");
     public static string TrackingSilver => LocalizationController.Translation("TRACKING_SILVER");
     public static string TrackingFame => LocalizationController.Translation("TRACKING_FAME");

--- a/src/StatisticsAnalysisTool/UserControls/DamageMeterControl.xaml
+++ b/src/StatisticsAnalysisTool/UserControls/DamageMeterControl.xaml
@@ -94,17 +94,21 @@
                                         Margin="0" Width="auto" VerticalAlignment="Top" Click="BtnDamageMeterReset_Click" />
                                         </StackPanel>
                                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,5,0,0">
-                                            <Grid Height="20" Width="20" Margin="5,0,5,0" HorizontalAlignment="Right" VerticalAlignment="Center" 
-                                                  ToolTip="{Binding Translation.OpenExtendedDamageMeterWindow, FallbackValue=OPEN__EXTENDED__DAMAGE__METER__WINDOW}" 
+                                            <Grid Height="20" Width="20" Margin="5,0,5,0" HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                  ToolTip="{Binding Translation.OpenExtendedDamageMeterWindow, FallbackValue=OPEN__EXTENDED__DAMAGE__METER__WINDOW}"
                                                   MouseUp="OpenDamageMeterWindow_MouseUp">
                                                 <fa5:ImageAwesome Icon="Solid_Expand" Foreground="{StaticResource SolidColorBrush.Text.1}" />
                                             </Grid>
-                                            <Grid Height="20" Width="20" Margin="5,0,5,0" HorizontalAlignment="Right" VerticalAlignment="Center" 
+                                            <Grid Height="20" Width="20" Margin="5,0,5,0" HorizontalAlignment="Right" VerticalAlignment="Center"
                                                   ToolTip="{Binding Translation.CopyToClipboard, FallbackValue=COPY__TO__CLIPBOARD}" MouseUp="CopyDamageMeterToClipboard_MouseUp">
                                                 <fa5:ImageAwesome Icon="Regular_Copy" Foreground="{StaticResource SolidColorBrush.Text.1}" />
                                             </Grid>
-                                            <Grid Height="20" Width="20" Margin="5,0,5,0" HorizontalAlignment="Right" VerticalAlignment="Center" 
-                                                  ToolTip="{Binding DamageMeterBindings.TranslationTakeASnapshotOfDamageMeterDescription, FallbackValue=TAKE_A_SNAPSHOT_OF_DAMAGE_METER}" 
+                                            <Grid Height="20" Width="20" Margin="5,0,5,0" HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                  ToolTip="{Binding Translation.ExportCombatLogToFile, FallbackValue=EXPORT__COMBAT__LOG__TO__FILE}" MouseUp="BtnExportCombatToCsv_MouseUp">
+                                                <fa5:ImageAwesome Icon="Solid_FileCsv" Foreground="{StaticResource SolidColorBrush.Accent.Green.4}" />
+                                            </Grid>
+                                            <Grid Height="20" Width="20" Margin="5,0,5,0" HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                  ToolTip="{Binding DamageMeterBindings.TranslationTakeASnapshotOfDamageMeterDescription, FallbackValue=TAKE_A_SNAPSHOT_OF_DAMAGE_METER}"
                                                   MouseUp="TakeASnapShot_MouseUp">
                                                 <fa5:ImageAwesome Icon="Solid_Camera" Foreground="{StaticResource SolidColorBrush.Text.1}" />
                                             </Grid>

--- a/src/StatisticsAnalysisTool/UserControls/DamageMeterControl.xaml.cs
+++ b/src/StatisticsAnalysisTool/UserControls/DamageMeterControl.xaml.cs
@@ -168,6 +168,12 @@ public partial class DamageMeterControl
         CopyDamageMeterToClipboard();
     }
 
+    private void BtnExportCombatToCsv_MouseUp(object sender, MouseButtonEventArgs e)
+    {
+        var mainWindowViewModel = ServiceLocator.Resolve<MainWindowViewModel>();
+        mainWindowViewModel?.ExportCombatLogToFile();
+    }
+
     private void CopyDamageMeterSnapshotToClipboard_MouseUp(object sender, MouseButtonEventArgs e)
     {
         CopyDamageMeterToClipboard(true);

--- a/src/StatisticsAnalysisTool/ViewModels/MainWindowViewModel.cs
+++ b/src/StatisticsAnalysisTool/ViewModels/MainWindowViewModel.cs
@@ -29,7 +29,9 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
+using System.Globalization;
 using System.Linq;
+using System.Text;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows;
@@ -394,6 +396,110 @@ public class MainWindowViewModel : BaseViewModel
                 Log.Error(e, "{message}", MethodBase.GetCurrentMethod()?.DeclaringType);
             }
         }
+    }
+
+    public void ExportCombatLogToFile()
+    {
+        if (!(DamageMeterBindings?.DamageMeter?.Any() ?? false))
+        {
+            return;
+        }
+
+        var dialog = new SaveFileDialog
+        {
+            FileName = $"combat-log-{DateTime.UtcNow:yyyy-MM-dd-HH-mm-ss}utc",
+            DefaultExt = ".csv",
+            Filter = "CSV documents (.csv)|*.csv"
+        };
+
+        var result = dialog.ShowDialog();
+        if (result == true)
+        {
+            try
+            {
+                var fragments = DamageMeterBindings.DamageMeter.ToList();
+                var csvContent = BuildCombatLogCsv(fragments);
+
+                if (!string.IsNullOrWhiteSpace(csvContent))
+                {
+                    File.WriteAllText(dialog.FileName, csvContent);
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "{message}", MethodBase.GetCurrentMethod()?.DeclaringType);
+            }
+        }
+    }
+
+    private static string BuildCombatLogCsv(IEnumerable<DamageMeterFragment> fragments)
+    {
+        if (fragments == null)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder();
+        builder.AppendLine("Name;Damage;Damage %;DPS;Heal;Heal %;HPS;Overhealed;Overhealed %;Taken Damage;Taken Damage %;Combat Time");
+
+        foreach (var fragment in fragments)
+        {
+            if (fragment == null)
+            {
+                continue;
+            }
+
+            var line = string.Join(';', new[]
+            {
+                EscapeCsvValue(fragment.Name),
+                fragment.Damage.ToString(CultureInfo.InvariantCulture),
+                FormatDouble(fragment.DamagePercentage),
+                FormatDouble(fragment.Dps),
+                fragment.Heal.ToString(CultureInfo.InvariantCulture),
+                FormatDouble(fragment.HealPercentage),
+                FormatDouble(fragment.Hps),
+                FormatDouble(fragment.Overhealed),
+                FormatDouble(fragment.OverhealedPercentageOfTotalHealing),
+                fragment.TakenDamage.ToString(CultureInfo.InvariantCulture),
+                FormatDouble(fragment.TakenDamagePercentage),
+                EscapeCsvValue(FormatCombatTime(fragment.CombatTime))
+            });
+
+            builder.AppendLine(line);
+        }
+
+        return builder.ToString();
+    }
+
+    private static string FormatCombatTime(TimeSpan combatTime)
+    {
+        var totalHours = (int) Math.Floor(combatTime.TotalHours);
+        return $"{totalHours:00}:{combatTime.Minutes:00}:{combatTime.Seconds:00}";
+    }
+
+    private static string EscapeCsvValue(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        if (value.Contains(';') || value.Contains('"') || value.Contains('\n') || value.Contains('\r'))
+        {
+            return $"\"{value.Replace("\"", "\"\"")}\"";
+        }
+
+        return value;
+    }
+
+    private static string FormatDouble(double value, string format = "F2")
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value))
+        {
+            value = 0;
+        }
+
+        return value.ToString(format, CultureInfo.InvariantCulture);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- add a CSV export icon to the damage meter toolbar and wire up its handler
- implement combat log CSV export logic and helper formatting in the main window view model
- provide a localized tooltip string for the new export action

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68c8a89b78588321ab0784fa364d4ff0